### PR TITLE
Do not overwrite transform in render_to_canvas

### DIFF
--- a/src/render_cairo/mod.rs
+++ b/src/render_cairo/mod.rs
@@ -76,7 +76,7 @@ pub fn render_to_canvas(cr: &cairo::Context, img_view: Rect, doc: &dom::Document
         let (dx, dy, sx, sy) = render_utils::view_box_transform(&doc.view_box, &img_view);
         cairo::Matrix::new(sx, 0.0, 0.0, sy, dx, dy)
     };
-    cr.set_matrix(ts);
+    cr.transform(ts);
 
     render_group(doc, &doc.elements, &cr, &cr.get_matrix(), img_view.size());
 }

--- a/src/render_qt/mod.rs
+++ b/src/render_qt/mod.rs
@@ -77,7 +77,7 @@ pub fn render_to_canvas(painter: &qt::Painter, img_view: Rect, doc: &dom::Docume
         let (dx, dy, sx, sy) = render_utils::view_box_transform(&doc.view_box, &img_view);
         qt::Transform::new(sx, 0.0, 0.0, sy, dx, dy)
     };
-    painter.set_transform(&ts);
+    painter.apply_transform(&ts);
 
     render_group(doc, &doc.elements, &painter, &painter.get_transform(), img_view.size());
 }


### PR DESCRIPTION
Hi, I just saw your announcement on reddit and tried [replacing](https://github.com/niklasf/rust-chessground/compare/resvg) librsvg with *libresvg* in my experimental chessboard project https://github.com/niklasf/rust-chessground.

It's using SVG to render the pieces and has to be able to apply arbitrary transforms before rendering. However `render_cairo::render_to_canvas` seems to disregard any previous transforms.

I tried to change that and it looks fine in my tests, but I am not sure if this is really correct.